### PR TITLE
fix: improve error handling and degraded mode behavior in FlagClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ await client.updateContext({
 | `persistContext`      | `boolean`                                 | `false`            | Persist evaluation context across sessions.                           |                                        |
 | `cacheAdapter`        | `CacheAdapter<C>`                         | Sync `cacheHelper` | Custom cache implementation (see examples).                           |
 | `transportMode`       | `'auto' \| 'websocket' \| 'long-polling'` | `'auto'`           | How to fetch flags: prefer WebSocket, or use long-polling transport.  |
-| `onError`             | `(error: Error) => void`                  | —                  | Callback for transport or initialization errors. Still throws on `ready()` if connection fails. |
+| `onError`             | `(error: Error) => void`                  | —                  | Callback for transport or initialization errors. Called when operating in degraded mode with cached flags. |
 | `previewMode`         | `boolean`                                 | `false`            | Evaluate using `rawFlags` only, bypassing remote fetch.               |
 | `rawFlags`            | `Record<string, FlagValue>`               | —                  | Local-only flag definitions used when `previewMode: true`.            |
 | `deferInitialization` | `boolean`                                 | `false`            | If `true`, client initialization is deferred until you call `ready()`. |
@@ -327,31 +327,39 @@ const client = new FlagClient({
 });
 ```
 
-**Important: Error Handling with Cache**
+**Important: Offline Fallback & Cache Behavior**
 
-When the server is unreachable but cached flags exist:
-- ✅ Cached flags ARE loaded and accessible via `getFlag()`
-- ⚠️ `onError` callback is called with the connection error
-- ❌ `ready()` promise still **rejects** with the error
+The SDK gracefully handles connection failures using cached flags as a fallback:
 
-This means you should handle both:
+**When the server is unreachable:**
+
+| Scenario | `ready()` Promise | Behavior |
+|----------|-------------------|----------|
+| ✅ Cached flags available | Resolves | Operates in degraded mode with cached flags |
+| ❌ No cached flags | Rejects | Initialization fails |
+| ✅ Connected successfully | Resolves | Normal operation with live updates |
+
+**Degraded Mode:** When `ready()` resolves but the connection failed, the `onError` callback is triggered to notify you:
 
 ```ts
 const client = new FlagClient({
   apiKey: '...',
   enableOfflineCache: true,
   onError: (error) => {
-    console.warn('Flagmint connection failed, using cached flags:', error);
+    // Called when operating in degraded mode with cached flags
+    console.warn('⚠️ Degraded mode - using cached flags:', error.message);
+    // Optionally report to monitoring service
   }
 });
 
 try {
   await client.ready();
-  console.log('Connected to Flagmint');
+  // ✅ Resolves successfully even if server is down (when cached flags exist)
+  console.log('Client ready');
+  const feature = client.getFlag('my_feature', false); // Always works
 } catch (error) {
-  console.error('Flagmint unreachable:', error);
-  // Cached flags are still available!
-  const feature = client.getFlag('my_feature', false); // Works!
+  // ❌ Only throws if NO cached flags AND server is unreachable
+  console.error('Completely offline:', error);
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagmint-js-sdk",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Framework-agnostic JavaScript SDK for managing feature flags in Flagmint applications.",
   "author": "Flagmint Team",
   "license": "MIT",

--- a/sdk/core/client.ts
+++ b/sdk/core/client.ts
@@ -180,11 +180,18 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
       logger.error('[FlagClient] Initialization failed:', error);
 
       if (Object.keys(this.flags).length > 0) {
-        logger.warn('[FlagClient] Transport connection failed. Serving cached flags.');
+        // Cached flags are available - operate in degraded mode
+        logger.warn('[FlagClient] Transport connection failed. Serving cached flags in degraded mode.');
+        this.isInitialized = true;
+        this.resolveReady();
+        // Notify about degraded mode via error callback
+        this.onError?.(error);
+      } else {
+        // No cached flags available - fail initialization
+        logger.error('[FlagClient] No cached flags available. Initialization failed.');
+        this.onError?.(error);
+        this.rejectReady(error);
       }
-
-      this.onError?.(error);
-      this.rejectReady(error);
     }
   }
 


### PR DESCRIPTION
This pull request updates the Flagmint JS SDK to improve how it handles server connection failures by introducing a clearer "degraded mode" when cached flags are available. The documentation and implementation have both been updated to clarify and support this behavior, making it easier for developers to understand and handle offline scenarios.

**Behavior and Documentation Improvements**

* Updated the documentation in `README.md` to clarify the SDK's behavior when the server is unreachable, including a new section and table explaining degraded mode and how the `onError` callback and `ready()` promise behave with or without cached flags.
* Improved the description of the `onError` option in the configuration table to specify that it is called when operating in degraded mode with cached flags.

**SDK Logic Changes**

* Modified `FlagClient` in `sdk/core/client.ts` to explicitly support degraded mode: when cached flags exist but the server is unreachable, the client now sets itself as initialized, resolves the `ready()` promise, and triggers the `onError` callback. If no cached flags are available, initialization fails as before.

**Versioning**

* Bumped the SDK version in `package.json` from `1.2.21` to `1.2.22` to reflect these changes.