### PR TITLE
feat: update version to 1.2.23 and enhance environment handling in Fl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagmint-js-sdk",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Framework-agnostic JavaScript SDK for managing feature flags in Flagmint applications.",
   "author": "Flagmint Team",
   "license": "MIT",

--- a/sdk/core/client.ts
+++ b/sdk/core/client.ts
@@ -101,8 +101,8 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
     this.cacheTTL = DEFAULT_CACHE_TTL;
     this.onError = options.onError;
     
-    // Compute endpoints based on provided env option or auto-detect
-    const endpoints = getDefaultEndpoints(options.env);
+    // Compute endpoints based on provided env option; if env is not set, use module-level defaults for backward compatibility
+    const endpoints = options.env ? getDefaultEndpoints(options.env) : { rest: DEFAULT_REST_ENDPOINT, ws: DEFAULT_WS_ENDPOINT };
     this.restEndpoint = options.restEndpoint ?? endpoints.rest;
     this.wsEndpoint = options.wsEndpoint ?? endpoints.ws;
     this.cacheAdapter = options.cacheAdapter ?? {

--- a/sdk/core/client.ts
+++ b/sdk/core/client.ts
@@ -8,6 +8,7 @@ import * as syncCache from '@/core/helpers/cacheHelper';
 import { logger } from '@/core/helpers/logger';
 
 type TransportMode = 'auto' | 'websocket' | 'long-polling';
+type Environment = 'production' | 'staging' | 'development';
 
 export interface FlagClientOptions<C extends Record<string, any> = Record<string, any>> {
   apiKey: string;
@@ -23,17 +24,17 @@ export interface FlagClientOptions<C extends Record<string, any> = Record<string
   cacheAdapter?: CacheAdapter<C>;
   restEndpoint?: string;
   wsEndpoint?: string;
+  env?: Environment;
 }
 
 const DEFAULT_CACHE_TTL = 24 * 60 * 60 * 1000;
 
 /**
- * Get default endpoints based on NODE_ENV
+ * Get default endpoints based on environment
  */
-function getDefaultEndpoints() {
-  const env =
-    (typeof process !== 'undefined' ? (process.env.NEXT_PUBLIC_NODE_ENV || process.env.NODE_ENV) : 'development');
-  switch (env) {
+function getDefaultEndpoints(env?: Environment): { rest: string; ws: string } {
+  const resolvedEnv = env || (typeof process !== 'undefined' ? (process.env.NEXT_PUBLIC_NODE_ENV || process.env.NODE_ENV) : 'development');
+  switch (resolvedEnv) {
     case 'production':
       return {
         rest: 'https://api.flagmint.com/evaluator/evaluate',
@@ -53,8 +54,10 @@ function getDefaultEndpoints() {
   }
 }
 
-const REST_ENDPOINT = getDefaultEndpoints().rest;
-const WS_ENDPOINT = getDefaultEndpoints().ws;
+// Note: Default endpoints are computed per-client based on the env option
+// These are kept for backward compatibility if no env is specified
+const DEFAULT_REST_ENDPOINT = getDefaultEndpoints().rest;
+const DEFAULT_WS_ENDPOINT = getDefaultEndpoints().ws;
 
 // Type for subscription callbacks
 type FlagUpdateCallback<T> = (flags: FeatureFlags<T>) => void;
@@ -97,8 +100,11 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
     this.persistContext = options.persistContext ?? false;
     this.cacheTTL = DEFAULT_CACHE_TTL;
     this.onError = options.onError;
-    this.restEndpoint = options.restEndpoint ?? REST_ENDPOINT;
-    this.wsEndpoint = options.wsEndpoint ?? WS_ENDPOINT;
+    
+    // Compute endpoints based on provided env option or auto-detect
+    const endpoints = getDefaultEndpoints(options.env);
+    this.restEndpoint = options.restEndpoint ?? endpoints.rest;
+    this.wsEndpoint = options.wsEndpoint ?? endpoints.ws;
     this.cacheAdapter = options.cacheAdapter ?? {
       loadFlags: syncCache.loadCachedFlags,
       saveFlags: syncCache.saveCachedFlags,


### PR DESCRIPTION
This pull request updates the SDK to allow explicit environment selection for endpoint configuration, making it easier to use different environments (production, staging, development) and improving flexibility for SDK consumers. The default endpoints are now determined per-client based on a new `env` option, but backward compatibility is maintained.

**Environment-based endpoint configuration:**

* Added an `env` option to the `FlagClientOptions` interface, allowing users to specify the environment (`'production'`, `'staging'`, or `'development'`). [[1]](diffhunk://#diff-fdb1f2b611adbeb28f7c418c002eb499d10f83ca4c94686826f69cc9a5a79f92R11) [[2]](diffhunk://#diff-fdb1f2b611adbeb28f7c418c002eb499d10f83ca4c94686826f69cc9a5a79f92R27-R37)
* Refactored the `getDefaultEndpoints` function to accept an optional environment parameter, defaulting to auto-detection if not provided.
* Updated the `FlagClient` constructor to compute endpoints based on the `env` option, falling back to the previous auto-detection logic if `env` is not specified.

**Backward compatibility:**

* Renamed static endpoint constants to `DEFAULT_REST_ENDPOINT` and `DEFAULT_WS_ENDPOINT`, and preserved their use for clients that do not specify an environment.

**Version bump:**

* Bumped package version from `1.2.22` to `1.2.23` in `package.json`.…agClient