### PR TITLE
add support for sub-flags,

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,29 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2025 Israel Edet
+Copyright (c) 2024, Flagmint
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Flagmint JavaScript SDK
 
-**Version: v1.2.24**
+**Version: v1.2.25**
 
 This SDK provides a javascript framework-agnostic client for evaluating feature flags, with pluggable caching (sync or async) and transport strategies (WebSocket or long-polling). It's designed for both browser and server-side Node.js environments.
 
 ## 📋 Release Notes
+
+### v1.2.25
+- 🔇 **Controllable debug logging** — SDK logs are now silent by default; opt in with `logger.setup({ debugLog: true })`. In production, only connection/disconnection messages are ever emitted regardless of the setting.
+- 🔌 **Configurable endpoints** — `restEndpoint` and `wsEndpoint` can now be passed directly in `FlagClientOptions`, overriding the environment-derived defaults. Useful for proxies, staging overrides, or self-hosted deployments.
+- 📡 **`subscribe()` delivers current flags immediately** — the callback is now called synchronously with the current flag state at subscription time, so you never miss the initial value.
+- 🧹 **`destroy()` clears all subscribers** — calling `destroy()` now also clears the subscriber set, preventing stale callbacks from holding references after teardown.
+- 🛡️ **WebSocket auth vs rate-limit error discrimination** — close code `1008`/`4001` now inspects the close reason to distinguish `ERR_AUTH` (invalid API key) from `ERR_RATE_LIMITED` errors. Rate-limit errors include a `resetTime` field parsed from the close reason.
+- 🔗 **`initialFlagsReject` on WebSocket transport** — a post-`onopen` close with a terminal code now correctly rejects the `waitForInitialFlags()` promise (and therefore `init()`), so the error surfaces reliably through `client.ready()` even when the connection opened before the server sent the close frame.
+- 🔔 **`onConnectionStateChanged()` exposed** — consumers can now register a callback to observe WebSocket connection state transitions (`connecting`, `connected`, `disconnected`, `reconnecting`, `failed`).
 
 ### v1.2.24
 - ✨ Add `env` parameter to SDK configuration for explicit environment specification
@@ -64,13 +73,37 @@ await client.updateContext({
 | `apiKey`              | `string`                                  | **Required**       | Your environment API key.                                             |
 | `context`             | `Record<string, any>`                     | `{}`               | Initial evaluation context (e.g. user attributes).                    |
 | `enableOfflineCache`  | `boolean`                                 | `true`              | Enable caching of flags locally.                                      |
-| `persistContext`      | `boolean`                                 | `false`            | Persist evaluation context across sessions.                           |                                        |
+| `persistContext`      | `boolean`                                 | `false`            | Persist evaluation context across sessions.                           |
 | `cacheAdapter`        | `CacheAdapter<C>`                         | Sync `cacheHelper` | Custom cache implementation (see examples).                           |
 | `transportMode`       | `'auto' \| 'websocket' \| 'long-polling'` | `'auto'`           | How to fetch flags: prefer WebSocket, or use long-polling transport.  |
+| `restEndpoint`        | `string`                                  | env-derived        | Override the REST endpoint (useful for proxies or self-hosted setups).|
+| `wsEndpoint`          | `string`                                  | env-derived        | Override the WebSocket endpoint.                                      |
 | `onError`             | `(error: Error) => void`                  | —                  | Callback for transport or initialization errors. Called when operating in degraded mode with cached flags. |
 | `previewMode`         | `boolean`                                 | `false`            | Evaluate using `rawFlags` only, bypassing remote fetch.               |
 | `rawFlags`            | `Record<string, FlagValue>`               | —                  | Local-only flag definitions used when `previewMode: true`.            |
 | `deferInitialization` | `boolean`                                 | `false`            | If `true`, client initialization is deferred until you call `ready()`. |
+
+## 🪵 Debug Logging
+
+By default the SDK is **silent** — no console output in any environment. To enable verbose logging during development, call `logger.setup()` before creating your client:
+
+```ts
+import { logger } from 'flagmint-js-sdk';
+
+logger.setup({ debugLog: true });
+
+const client = new FlagClient({ apiKey: '...' });
+```
+
+In **production** (`NODE_ENV=production`), only connection and disconnection messages are emitted regardless of the `debugLog` setting — all other internal logs are suppressed.
+
+```ts
+// These messages always appear in production:
+// "[WebSocketTransport] Connected"
+// "[WebSocketTransport] Connection closed: 1000"
+
+// All other internal logs require debugLog: true in non-production environments
+```
 
 ## 🔧 Cache Adapters
 
@@ -115,6 +148,32 @@ const client = new FlagClient({
 const client = new FlagClient({
   apiKey: '...',
   transportMode: 'long-polling'
+});
+```
+
+### Custom Endpoints
+
+Override the default environment-derived endpoints — useful for proxies, staging overrides, or self-hosted deployments:
+
+```ts
+const client = new FlagClient({
+  apiKey: '...',
+  restEndpoint: 'https://my-proxy.example.com/evaluator/evaluate',
+  wsEndpoint:   'wss://my-proxy.example.com/ws/sdk',
+});
+```
+
+### WebSocket Connection State
+
+Monitor connection state transitions by accessing the underlying WebSocket transport directly:
+
+```ts
+import { WebSocketTransport } from 'flagmint-js-sdk';
+
+const ws = new WebSocketTransport(wsUrl, apiKey);
+ws.onConnectionStateChanged((state) => {
+  // state: 'connecting' | 'connected' | 'disconnected' | 'reconnecting' | 'failed'
+  console.log('WS state:', state);
 });
 ```
 
@@ -342,7 +401,7 @@ The SDK gracefully handles connection failures using cached flags as a fallback:
 
 | Scenario | `ready()` Promise | Behavior |
 |----------|-------------------|----------|
-| ✅ Cached flags available | Resolves | Operates in degraded mode with cached flags |
+| ✅ Cached flags available | Resolves | Operates in degraded mode with cached flags; `onError` is called |
 | ❌ No cached flags | Rejects | Initialization fails |
 | ✅ Connected successfully | Resolves | Normal operation with live updates |
 
@@ -435,17 +494,17 @@ const client = new FlagClient({
 - `getFlag<K>(key: K, fallback?: T): T` - Get flag value with optional fallback
 - `getFlags(): FeatureFlags<T>` - Get all flags as an object
 - `updateContext(context: Record<string, any>): Promise<void>` - Update evaluation context (async)
-- `subscribe(callback: (flags) => void): () => void` - Subscribe to flag updates, returns unsubscribe function
-- `destroy(): void` - Close transport connection and cleanup resources
+- `subscribe(callback: (flags) => void): () => void` - Subscribe to flag updates; fires immediately with current flags, returns unsubscribe function
+- `destroy(): void` - Close transport connection, clear all subscribers, and release resources
 
 ### Subscribing to Flag Updates
 
-Instead of event listeners, use the `subscribe()` method:
+Instead of event listeners, use the `subscribe()` method. The callback is called **immediately** with the current flag state at subscription time, then again on every subsequent update:
 
 ```ts
 const unsubscribe = client.subscribe((flags) => {
   console.log('Flags updated:', flags);
-  // Handle flag updates
+  // Also fires immediately with current flags — no need to call getFlags() separately
 });
 
 // Later, to unsubscribe:
@@ -509,11 +568,9 @@ sdk/
 
 **Important**: When `enableOfflineCache: true` (default):
 - Cached flags are loaded even if the server is unreachable
-- `ready()` will still throw an error on connection failure
-- You can still access cached flags via `getFlag()` after catching the error
-- Consider wrapping `ready()` in try/catch and continuing with cached data
-
-See the "Error Handling with Cache" section above for examples.
+- `ready()` **resolves** (does not throw) if cached flags are available — the `onError` callback is invoked instead to signal degraded mode
+- `ready()` only rejects if **no cached flags exist** and the server is unreachable
+- You can safely call `getFlag()` after `ready()` resolves, regardless of whether the connection succeeded
 
 ### Performance issues
 
@@ -541,6 +598,6 @@ See [GitHub Releases](https://github.com/flagmint/js-sdk/releases) for the compl
 
 ---
 
-**License**: MIT © Flagmint Team
+**License**: BSD 3-Clause License © Flagmint Team
 
 **Maintained with ❤️ by the Flagmint Team**

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "flagmint-js-sdk",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "Framework-agnostic JavaScript SDK for managing feature flags in Flagmint applications.",
   "author": "Flagmint Team",
-  "license": "MIT",
+  "license": "BSD 3-Clause",
   "main": "dist/flagmint.cjs.js",
   "module": "dist/flagmint.es.js",
   "types": "dist/index.d.ts",

--- a/sdk/core/client.ts
+++ b/sdk/core/client.ts
@@ -6,10 +6,8 @@ import { FlagValue } from '@/core/evaluation/types';
 import { evaluateFlagValue } from '@/core/evaluation/evaluateFlagValue';
 import * as syncCache from '@/core/helpers/cacheHelper';
 import { logger } from '@/core/helpers/logger';
-import { UpdateContextOptionsProps } from './types';
 
 type TransportMode = 'auto' | 'websocket' | 'long-polling';
-type Environment = 'production' | 'staging' | 'development';
 
 export interface FlagClientOptions<C extends Record<string, any> = Record<string, any>> {
   apiKey: string;
@@ -18,6 +16,19 @@ export interface FlagClientOptions<C extends Record<string, any> = Record<string
   persistContext?: boolean;
   transport?: Transport<C, any>;
   transportMode?: TransportMode;
+  /**
+   * Called when a non-fatal but noteworthy error occurs during or after initialization.
+   * The client always resolves ready() regardless — use this to show a degraded/fallback UI.
+   *
+   * Common cases:
+   *  - Auth failure (err.code === 'ERR_AUTH'): API key invalid; flags will be empty; getFlag() returns fallback values.
+   *  - Rate limited (err.code === 'ERR_RATE_LIMITED'): free-tier call limit exceeded; cached flags are served if available.
+   *    Check (err as any).resetTime for the reset timestamp string supplied by the server, if present.
+   *  - Degraded mode: transport failed but cached flags are available and being served.
+   *  - Context update error: re-evaluation after updateContext() failed; previous flags retained.
+   *
+   * Note: ready() will never throw. All errors are surfaced exclusively through this callback.
+   */
   onError?: (error: Error) => void;
   previewMode?: boolean;
   rawFlags?: Record<string, FlagValue>;
@@ -25,17 +36,20 @@ export interface FlagClientOptions<C extends Record<string, any> = Record<string
   cacheAdapter?: CacheAdapter<C>;
   restEndpoint?: string;
   wsEndpoint?: string;
-  env?: Environment;
+  debugLog?: boolean; // this option should be true, if a user wants access to flagmint internal logs
+  env?: string;
+  enableFlagmint: boolean; // this is used to trigger connection to Flagmint service. This prevents connection when in dev and reduced billing.
 }
 
 const DEFAULT_CACHE_TTL = 24 * 60 * 60 * 1000;
 
 /**
- * Get default endpoints based on environment
+ * Get default endpoints based on NODE_ENV
  */
-function getDefaultEndpoints(env?: Environment): { rest: string; ws: string } {
-  const resolvedEnv = env || (typeof process !== 'undefined' ? (process.env.NEXT_PUBLIC_NODE_ENV || process.env.NODE_ENV) : 'development');
-  switch (resolvedEnv) {
+function getDefaultEndpoints(env?: string): { rest: string; ws: string } {
+  const environment =
+    env || (typeof process !== 'undefined' ? (process.env.NEXT_PUBLIC_NODE_ENV || process.env.NODE_ENV) : 'production');
+  switch (environment?.toLowerCase()) {
     case 'production':
       return {
         rest: 'https://api.flagmint.com/evaluator/evaluate',
@@ -49,19 +63,17 @@ function getDefaultEndpoints(env?: Environment): { rest: string; ws: string } {
     case 'development':
     default:
       return {
-        rest: 'http://localhost:3000/evaluator/evaluate',
-        ws: 'ws://localhost:3000/ws/sdk',
+        rest: 'https://api.flagmint.com/evaluator/evaluate',
+        ws: 'wss://api.flagmint.com/ws/sdk',
       };
   }
 }
 
-// Note: Default endpoints are computed per-client based on the env option
-// These are kept for backward compatibility if no env is specified
-const DEFAULT_REST_ENDPOINT = getDefaultEndpoints().rest;
-const DEFAULT_WS_ENDPOINT = getDefaultEndpoints().ws;
+const REST_ENDPOINT = getDefaultEndpoints().rest;
+const WS_ENDPOINT = getDefaultEndpoints().ws;
 
 // Type for subscription callbacks
-type FlagUpdateCallback<T> = (flags: FeatureFlags<T> | Record<string, FeatureFlags<T>>) => void;
+type FlagUpdateCallback<T> = (flags: FeatureFlags<T>) => void;
 
 export class FlagClient<T = unknown, C extends Record<string, any> = Record<string, any>> {
   private apiKey: string;
@@ -81,9 +93,10 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
   private onError?: (error: Error) => void;
   private previewMode: boolean;
   private rawFlags: Record<string, FlagValue> = {};
-  private subFlags: Map<string, { flags: FeatureFlags<T>; timeoutId: NodeJS.Timeout }> = new Map();
-  private subFlagsubscribers: Map<string, Set<FlagUpdateCallback<T>>> = new Map();
   private cacheAdapter: CacheAdapter<C>;
+
+  private env?: string;
+  private enableFlagmint?: boolean;
 
   // NEW: Track if initialization was deferred
   private deferInitialization: boolean;
@@ -103,11 +116,8 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
     this.persistContext = options.persistContext ?? false;
     this.cacheTTL = DEFAULT_CACHE_TTL;
     this.onError = options.onError;
-    
-    // Compute endpoints based on provided env option; if env is not set, use module-level defaults for backward compatibility
-    const endpoints = options.env ? getDefaultEndpoints(options.env) : { rest: DEFAULT_REST_ENDPOINT, ws: DEFAULT_WS_ENDPOINT };
-    this.restEndpoint = options.restEndpoint ?? endpoints.rest;
-    this.wsEndpoint = options.wsEndpoint ?? endpoints.ws;
+    this.restEndpoint = getDefaultEndpoints(options.env).rest ?? REST_ENDPOINT;
+    this.wsEndpoint = getDefaultEndpoints(options.env).ws ?? WS_ENDPOINT;
     this.cacheAdapter = options.cacheAdapter ?? {
       loadFlags: syncCache.loadCachedFlags,
       saveFlags: syncCache.saveCachedFlags,
@@ -119,6 +129,10 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
     this.rawFlags = options.rawFlags ?? {};
     this.previewMode = options.previewMode || false;
     this.deferInitialization = options.deferInitialization ?? false;
+    this.env = options.env;
+    this.enableFlagmint = options.enableFlagmint ?? true;
+
+    logger.setup({ debugLog: options.debugLog });
 
     // Local-only evaluation
     if (this.previewMode && this.rawFlags && Object.keys(this.rawFlags).length > 0) {
@@ -136,14 +150,19 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
       this.resolveReady = resolve;
       this.rejectReady = reject;
     });
-    if (this.deferInitialization) {
-      logger.log('[FlagClient] Initialization deferred. Call ready() to initialize.');
-      // Store options for later initialization
-      this.initializationOptions = options;
-      // Don't initialize yet!
+
+    if(this.enableFlagmint) {
+      if (this.deferInitialization) {
+        logger.log('[FlagClient] Initialization deferred. Call ready() to initialize.');
+        // Store options for later initialization
+        this.initializationOptions = options;
+        // Don't initialize yet!
+      } else {
+        // Initialize immediately (existing behavior)
+        void this.initialize(options);
+      }
     } else {
-      // Initialize immediately (existing behavior)
-      void this.initialize(options);
+      logger.log('[FlagClient] Flagmint connection disabled. Skipping initialization.');
     }
   }
 
@@ -151,7 +170,7 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
    * Initializes the client by loading cached flags and context, setting up the transport layer.
    */
   private async initialize(options: FlagClientOptions<C>): Promise<void> {
-    logger.log('[FlagClient] Initialization started with options:', options);
+    logger.log('[FlagClient] Initialization started');
     if (this.isInitialized) {
       logger.log('[FlagClient] Already initialized, skipping.');
       return;
@@ -188,19 +207,19 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
       const error = err instanceof Error ? err : new Error(String(err));
       logger.error('[FlagClient] Initialization failed:', error);
 
+      // Always resolve — the app should render its fallback UI regardless of whether
+      // we have cached flags or not. onError carries the reason; ready() must not throw
+      // because most call sites (Vue plugin, React hooks) don't wrap it in try/catch.
+      // Cached flags, if any, are already in this.flags from step B above.
       if (Object.keys(this.flags).length > 0) {
-        // Cached flags are available - operate in degraded mode
         logger.warn('[FlagClient] Transport connection failed. Serving cached flags in degraded mode.');
-        this.isInitialized = true;
-        this.resolveReady();
-        // Notify about degraded mode via error callback
-        this.onError?.(error);
       } else {
-        // No cached flags available - fail initialization
-        logger.error('[FlagClient] No cached flags available. Initialization failed.');
-        this.onError?.(error);
-        this.rejectReady(error);
+        logger.warn('[FlagClient] Transport connection failed. No cached flags — getFlag() will return fallback values.');
       }
+
+      this.onError?.(error);
+      this.isInitialized = true;
+      this.resolveReady();
     }
   }
 
@@ -243,6 +262,8 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
       try {
         this.transport = await useWebSocket();
       } catch (e) {
+        const code = (e as any).code;
+        if (code === 'ERR_AUTH' || code === 'ERR_RATE_LIMITED') throw e; // both terminal — long polling hits the same wall
         logger.warn('[FlagClient] WebSocket failed, falling back to long polling');
         this.transport = useLongPolling();
       }
@@ -263,16 +284,11 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
    * Updates flags and notifies all subscribers.
    * This is the centralized method for any flag update.
    */
-  private updateFlags(newFlags: FeatureFlags<T>, options: UpdateContextOptionsProps = {key: null}): void {
-    if(!options.key) {
-      // No sub-context key, update main flags directly
-      this.flags = newFlags;
-    } else {
-      this.updateSubFlags(options?.key, newFlags, options?.subFlagTTL)
-    }
+  private updateFlags(newFlags: FeatureFlags<T>): void {
+    this.flags = newFlags;
 
     // Cache the new flags
-    if (this.enableOfflineCache && options?.key === null) {
+    if (this.enableOfflineCache) {
       void Promise.resolve(
         this.cacheAdapter.saveFlags(this.apiKey, newFlags)
       );
@@ -280,28 +296,6 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
 
     // Notify all subscribers
     this.notifySubscribers();
-  }
-/**
- * Update the subFlags 
- * @param subContextKey 
- * @param newFlags 
- * @param subFlagTTL 
- */
-  private updateSubFlags(subContextKey: string, newFlags: FeatureFlags<T>, subFlagTTL: number = 5 * 60 * 1000): void {
-    if(subContextKey && typeof subContextKey === 'string') {
-      // If a sub-context key is provided, we store the flags in a sub-context
-      if(!this.subFlags.has(subContextKey)) {
-        this.subFlags.set(subContextKey, { flags: {} as FeatureFlags<T>, timeoutId: null }); // Initialize sub-context if it doesn't exist
-      }
-      this.subFlags.get(subContextKey)!.flags = newFlags as FeatureFlags<T>; // Store new flags in the sub-context
-      // Set a timeout to remove the sub-context after TTL expires
-      const key = subContextKey;
-      setTimeout(() => {
-        this.subFlags.delete(key);
-        logger.log(`[FlagClient] Sub-context '${key}' expired and removed.`);
-        this.notifySubscribers(); // Notify subscribers after removal
-      }, subFlagTTL); // Default TTL: 5 minutes
-    }
   }
 
   /**
@@ -322,23 +316,7 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
    * @param callback - Function to call when flags update
    * @returns Unsubscribe function
    */
-  subscribe(callback: FlagUpdateCallback<T>, subContextKey?: string): () => void {
-    if (subContextKey) {
-      if (!this.subFlagsubscribers.has(subContextKey)) {
-        this.subFlagsubscribers.set(subContextKey, new Set());
-      }
-      this.subFlagsubscribers.get(subContextKey)!.add(callback);
-      
-      // immediate call — passes sub-context flags if already resolved, {} if pending
-      const current = this.subFlags.get(subContextKey);
-      callback(current?.flags ?? {} as FeatureFlags<T>);
-      
-      return () => {
-        const set = this.subFlagsubscribers.get(subContextKey);
-        set?.delete(callback);
-        if (set?.size === 0) this.subFlagsubscribers.delete(subContextKey);
-      };
-    }
+  subscribe(callback: FlagUpdateCallback<T>): () => void {
     this.subscribers.add(callback);
     // Immediately call with current flags
     callback(this.flags);
@@ -351,37 +329,21 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
   /**
    * Get all flags.
    */
-  getFlags(): FeatureFlags<T> | Record<string, FeatureFlags<T>> {
+  getFlags(): FeatureFlags<T> {
     return { ...this.flags };
   }
 
   /**
    * Get a single flag value.
-   * @param key - The key of the flag to retrieve
-   * @param fallback - Optional fallback value if the flag is not found
-   * @returns The flag value or the fallback
    */
-  getFlag<K extends keyof FeatureFlags<T>>(key: K, fallback?: FeatureFlags<T>[K], subContextKey?: string): FeatureFlags<T>[K] {
-    if (subContextKey) {
-      const sub = this.subFlags.get(subContextKey);
-      if (sub) {
-        // sub-context exists and hasn't expired — read from it
-        return sub.flags[key] ?? fallback!;
-      }
-      // sub-context was requested but doesn't exist (never set, or expired)
-      return fallback!;
-    }
+  getFlag<K extends keyof FeatureFlags<T>>(key: K, fallback?: FeatureFlags<T>[K]): FeatureFlags<T>[K] {
     return this.flags[key] ?? fallback!;
   }
 
   /**
    * Update the evaluation context.
-   * This will trigger a re-evaluation of flags based on the new context.
-   * @param context - New context to merge with existing context
-   * @param options - Optional sub-context and TTL for temporary context
-   * @returns Promise that resolves when the update is complete
    */
-  async updateContext(context: C, options: UpdateContextOptionsProps = {key: null}): Promise<void> {
+  async updateContext(context: C): Promise<void> {
     this.context = { ...this.context, ...context };
     if (this.initializationOptions) {
       this.initializationOptions.context = this.context; // Ensure context is passed if it was set after construction
@@ -397,7 +359,7 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
       try {
         const updatedFlags = await this.transport.fetchFlags(this.context);
         logger.log('[FlagClient] Flags updated after context change:', updatedFlags);
-        this.updateFlags(updatedFlags, options);
+        this.updateFlags(updatedFlags);
       } catch (error) {
         logger.error('[FlagClient] Error updating flags after context change:', error);
         this.onError?.(error as Error);

--- a/sdk/core/client.ts
+++ b/sdk/core/client.ts
@@ -6,6 +6,7 @@ import { FlagValue } from '@/core/evaluation/types';
 import { evaluateFlagValue } from '@/core/evaluation/evaluateFlagValue';
 import * as syncCache from '@/core/helpers/cacheHelper';
 import { logger } from '@/core/helpers/logger';
+import { UpdateContextOptionsProps } from './types';
 
 type TransportMode = 'auto' | 'websocket' | 'long-polling';
 type Environment = 'production' | 'staging' | 'development';
@@ -60,7 +61,7 @@ const DEFAULT_REST_ENDPOINT = getDefaultEndpoints().rest;
 const DEFAULT_WS_ENDPOINT = getDefaultEndpoints().ws;
 
 // Type for subscription callbacks
-type FlagUpdateCallback<T> = (flags: FeatureFlags<T>) => void;
+type FlagUpdateCallback<T> = (flags: FeatureFlags<T> | Record<string, FeatureFlags<T>>) => void;
 
 export class FlagClient<T = unknown, C extends Record<string, any> = Record<string, any>> {
   private apiKey: string;
@@ -80,6 +81,8 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
   private onError?: (error: Error) => void;
   private previewMode: boolean;
   private rawFlags: Record<string, FlagValue> = {};
+  private subFlags: Map<string, { flags: FeatureFlags<T>; timeoutId: NodeJS.Timeout }> = new Map();
+  private subFlagsubscribers: Map<string, Set<FlagUpdateCallback<T>>> = new Map();
   private cacheAdapter: CacheAdapter<C>;
 
   // NEW: Track if initialization was deferred
@@ -260,11 +263,16 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
    * Updates flags and notifies all subscribers.
    * This is the centralized method for any flag update.
    */
-  private updateFlags(newFlags: FeatureFlags<T>): void {
-    this.flags = newFlags;
+  private updateFlags(newFlags: FeatureFlags<T>, options: UpdateContextOptionsProps = {key: null}): void {
+    if(!options.key) {
+      // No sub-context key, update main flags directly
+      this.flags = newFlags;
+    } else {
+      this.updateSubFlags(options?.key, newFlags, options?.subFlagTTL)
+    }
 
     // Cache the new flags
-    if (this.enableOfflineCache) {
+    if (this.enableOfflineCache && options?.key === null) {
       void Promise.resolve(
         this.cacheAdapter.saveFlags(this.apiKey, newFlags)
       );
@@ -272,6 +280,28 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
 
     // Notify all subscribers
     this.notifySubscribers();
+  }
+/**
+ * Update the subFlags 
+ * @param subContextKey 
+ * @param newFlags 
+ * @param subFlagTTL 
+ */
+  private updateSubFlags(subContextKey: string, newFlags: FeatureFlags<T>, subFlagTTL: number = 5 * 60 * 1000): void {
+    if(subContextKey && typeof subContextKey === 'string') {
+      // If a sub-context key is provided, we store the flags in a sub-context
+      if(!this.subFlags.has(subContextKey)) {
+        this.subFlags.set(subContextKey, { flags: {} as FeatureFlags<T>, timeoutId: null }); // Initialize sub-context if it doesn't exist
+      }
+      this.subFlags.get(subContextKey)!.flags = newFlags as FeatureFlags<T>; // Store new flags in the sub-context
+      // Set a timeout to remove the sub-context after TTL expires
+      const key = subContextKey;
+      setTimeout(() => {
+        this.subFlags.delete(key);
+        logger.log(`[FlagClient] Sub-context '${key}' expired and removed.`);
+        this.notifySubscribers(); // Notify subscribers after removal
+      }, subFlagTTL); // Default TTL: 5 minutes
+    }
   }
 
   /**
@@ -292,7 +322,23 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
    * @param callback - Function to call when flags update
    * @returns Unsubscribe function
    */
-  subscribe(callback: FlagUpdateCallback<T>): () => void {
+  subscribe(callback: FlagUpdateCallback<T>, subContextKey?: string): () => void {
+    if (subContextKey) {
+      if (!this.subFlagsubscribers.has(subContextKey)) {
+        this.subFlagsubscribers.set(subContextKey, new Set());
+      }
+      this.subFlagsubscribers.get(subContextKey)!.add(callback);
+      
+      // immediate call — passes sub-context flags if already resolved, {} if pending
+      const current = this.subFlags.get(subContextKey);
+      callback(current?.flags ?? {} as FeatureFlags<T>);
+      
+      return () => {
+        const set = this.subFlagsubscribers.get(subContextKey);
+        set?.delete(callback);
+        if (set?.size === 0) this.subFlagsubscribers.delete(subContextKey);
+      };
+    }
     this.subscribers.add(callback);
     // Immediately call with current flags
     callback(this.flags);
@@ -305,21 +351,37 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
   /**
    * Get all flags.
    */
-  getFlags(): FeatureFlags<T> {
+  getFlags(): FeatureFlags<T> | Record<string, FeatureFlags<T>> {
     return { ...this.flags };
   }
 
   /**
    * Get a single flag value.
+   * @param key - The key of the flag to retrieve
+   * @param fallback - Optional fallback value if the flag is not found
+   * @returns The flag value or the fallback
    */
-  getFlag<K extends keyof FeatureFlags<T>>(key: K, fallback?: FeatureFlags<T>[K]): FeatureFlags<T>[K] {
+  getFlag<K extends keyof FeatureFlags<T>>(key: K, fallback?: FeatureFlags<T>[K], subContextKey?: string): FeatureFlags<T>[K] {
+    if (subContextKey) {
+      const sub = this.subFlags.get(subContextKey);
+      if (sub) {
+        // sub-context exists and hasn't expired — read from it
+        return sub.flags[key] ?? fallback!;
+      }
+      // sub-context was requested but doesn't exist (never set, or expired)
+      return fallback!;
+    }
     return this.flags[key] ?? fallback!;
   }
 
   /**
    * Update the evaluation context.
+   * This will trigger a re-evaluation of flags based on the new context.
+   * @param context - New context to merge with existing context
+   * @param options - Optional sub-context and TTL for temporary context
+   * @returns Promise that resolves when the update is complete
    */
-  async updateContext(context: C): Promise<void> {
+  async updateContext(context: C, options: UpdateContextOptionsProps = {key: null}): Promise<void> {
     this.context = { ...this.context, ...context };
     if (this.initializationOptions) {
       this.initializationOptions.context = this.context; // Ensure context is passed if it was set after construction
@@ -335,7 +397,7 @@ export class FlagClient<T = unknown, C extends Record<string, any> = Record<stri
       try {
         const updatedFlags = await this.transport.fetchFlags(this.context);
         logger.log('[FlagClient] Flags updated after context change:', updatedFlags);
-        this.updateFlags(updatedFlags);
+        this.updateFlags(updatedFlags, options);
       } catch (error) {
         logger.error('[FlagClient] Error updating flags after context change:', error);
         this.onError?.(error as Error);

--- a/sdk/core/helpers/ensureContextSource.ts
+++ b/sdk/core/helpers/ensureContextSource.ts
@@ -16,7 +16,7 @@ export function ensureContextSource<C>(context: C): C {
       ? sourceFromFlat
       : typeof sourceFromCustom === 'string'
         ? sourceFromCustom
-        : 'API';
+        : 'SDK';
 
   return {
     ...contextRecord,

--- a/sdk/core/helpers/logger.ts
+++ b/sdk/core/helpers/logger.ts
@@ -27,12 +27,12 @@ function getEnvironment(): Environment {
 /**
  * Check if logging is allowed based on environment and message
  */
-function shouldLog(message: string, level: LogLevel): boolean {
+function shouldLog(message: string, level: LogLevel, canDebug: boolean): boolean {
   const env = getEnvironment();
 
   // Allow all logging in non-production environments
   const allowedEnvs = ['staging', 'sandbox', 'acceptance', 'local', 'testing', 'development'];
-  if (allowedEnvs.includes(env)) {
+  if (allowedEnvs.includes(env) && canDebug) {
     return true;
   }
 
@@ -46,39 +46,47 @@ function shouldLog(message: string, level: LogLevel): boolean {
   }
 
   // Default: allow logging
-  return true;
+  return canDebug ?  true : false;
 }
 
 /**
  * Environment-aware logger that respects production restrictions
  */
 export const logger = {
+  canDebugLog : false,
+  setup: (options: { debugLog?: boolean }) => {
+    if (options.debugLog) {
+      logger.canDebugLog = options.debugLog
+    } else {
+      logger.canDebugLog = false;
+    }
+  },
   log: (message: string, ...args: any[]) => {
-    if (shouldLog(message, 'log')) {
+    if (shouldLog(message, 'log', logger.canDebugLog)) {
       console.log(message, ...args);
     }
   },
 
   error: (message: string, ...args: any[]) => {
-    if (shouldLog(message, 'error')) {
+    if (shouldLog(message, 'error', logger.canDebugLog)) {
       console.error(message, ...args);
     }
   },
 
   warn: (message: string, ...args: any[]) => {
-    if (shouldLog(message, 'warn')) {
+    if (shouldLog(message, 'warn', logger.canDebugLog)) {
       console.warn(message, ...args);
     }
   },
 
   info: (message: string, ...args: any[]) => {
-    if (shouldLog(message, 'info')) {
+    if (shouldLog(message, 'info', logger.canDebugLog)) {
       console.info(message, ...args);
     }
   },
 
   debug: (message: string, ...args: any[]) => {
-    if (shouldLog(message, 'debug')) {
+    if (shouldLog(message, 'debug', logger.canDebugLog)) {
       console.debug(message, ...args);
     }
   },

--- a/sdk/core/transports/WebsocketTransport.ts
+++ b/sdk/core/transports/WebsocketTransport.ts
@@ -38,6 +38,7 @@ export class WebSocketTransport<C, T> implements Transport<C, T> {
   private initialFlagsReceived = false;
   private initialFlagsPromise: Promise<void> | null = null;
   private initialFlagsResolve: (() => void) | null = null;
+  private initialFlagsReject: ((err: Error) => void) | null = null;
   private onFlagsUpdatedCallback?: (flags: Record<string, T>) => void;
   private onConnectionStateCallback?: (state: ConnectionState) => void;
   private retries = 0;
@@ -62,8 +63,9 @@ export class WebSocketTransport<C, T> implements Transport<C, T> {
     }
 
     if (!this.initialFlagsPromise) {
-      this.initialFlagsPromise = new Promise((resolve) => {
+      this.initialFlagsPromise = new Promise((resolve, reject) => {
         this.initialFlagsResolve = resolve;
+        this.initialFlagsReject = reject;
       });
     }
 
@@ -139,10 +141,30 @@ export class WebSocketTransport<C, T> implements Transport<C, T> {
             this.isReady = false;
             this.setConnectionState('disconnected');
 
-            // Auth failure codes
+            // Terminal close codes — do not retry
             if (event.code === 1008 || event.code === 4001) {
               this.setConnectionState('failed');
-              reject(new Error('Unauthorized: Invalid API key'));
+              const reason = event.reason ?? '';
+              const isRateLimit =
+                reason.toLowerCase().includes('rate limit') ||
+                reason.toLowerCase().includes('too many');
+
+              const err = isRateLimit
+                ? Object.assign(new Error(reason || 'Rate limit exceeded. Please try again later.'), {
+                    code: 'ERR_RATE_LIMITED',
+                    resetTime: reason.match(/after (.+)$/i)?.[1]?.trim(),
+                  })
+                : Object.assign(new Error('Unauthorized: Invalid API key'), { code: 'ERR_AUTH' });
+
+              // If onopen already fired and resolved connectWithRetry, the connectWithRetry
+              // reject() here is a no-op on the settled promise. In that case we must reject
+              // the flags promise so that waitForInitialFlags() — and therefore init() — throws.
+              if (this.initialFlagsReject) {
+                this.initialFlagsReject(err);
+                this.initialFlagsReject = null;
+                this.initialFlagsResolve = null;
+              }
+              reject(err); // no-op if connectWithRetry already resolved, but covers pre-open close
               return;
             }
 
@@ -249,6 +271,7 @@ export class WebSocketTransport<C, T> implements Transport<C, T> {
     this.initialFlagsReceived = false;
     this.initialFlagsPromise = null;
     this.initialFlagsResolve = null;
+    this.initialFlagsReject = null;
     this.onFlagsUpdatedCallback = undefined;
     this.onConnectionStateCallback = undefined;
     this.retries = 0;

--- a/sdk/core/types.ts
+++ b/sdk/core/types.ts
@@ -18,3 +18,8 @@ export interface FlagClientOptions<C extends Record<string, any> = Record<string
   rawFlags?: Record<string, FlagValue>;
   deferInitialization?: boolean; // If true, initialization is deferred until the user calls the init function
 }
+// we want when a user calls updateContext, they might want to persist the new update in a sub-context, used just for that component and deleted after a certain time. so we would want to have an option to pass a sub-context that will be merged with the main context and then removed after a certain time. This is useful for example when a user wants to test a new feature in a specific component without affecting the rest of the application. The sub-context would be used just for that component and then removed after a certain time.
+export interface UpdateContextOptionsProps {
+  key: string | null; // the key of the sub-context, used to identify it
+  subFlagTTL?: number; // ms, optional. Default: 5min
+}


### PR DESCRIPTION
# feat(vue-sdk): Gate Component sub-context flag evaluation
 
## Summary
 
Adds isolated, per-instance flag evaluation to `<FlagmintFeatureGate>` via a `contextNamespace` prop. When set, the Gate fetches and evaluates flags against its own override context without affecting the global client state, other Gates, or any other reactive consumer in the app.
 
This is the Vue SDK implementation of the sub-context evaluation design established in CLIENT-01.
 
---
 
## Motivation
 
Before this change, `<FlagmintFeatureGate>` could only evaluate flags against the global context set at plugin install time. Product teams needed a way to evaluate flags for a specific user, role, plan, or segment at the component level — for example, gating a feature for a user whose plan differs from the app's global context — without calling `updateContext()` and overwriting the context for the entire app.
 
---
 
## What changed
 
### `flagmint-js-sdk` — `FlagClient`
 
**New private state**
 
- `subFlags: Map<string, { flags: FeatureFlags<T>; timeoutId: NodeJS.Timeout | null }>` — isolated flag storage per namespace key, completely separate from `this.flags`.
- `subFlagSubscribers: Map<string, Set<FlagUpdateCallback<T>>>` — subscriber sets scoped per namespace key, so only the Gate(s) registered under a given key are notified when that key's flags update or expire.
 
**`updateFlags(newFlags, options)`** — split into two fully isolated paths:
- No `options.key` → writes to `this.flags`, saves to `cacheAdapter` (if offline cache enabled), calls `notifySubscribers()`. Unchanged from before.
- `options.key` set → delegates to `updateSubFlags()`, calls `notifySubFlagSubscribers(key)`. Never touches `this.flags` or `cacheAdapter`.
 
**`updateSubFlags(subContextKey, newFlags, subFlagTTL)`** — new private method:
- `clearTimeout` on any prior timer for the same key before arming a new one — prevents stale timers from deleting fresh data when the same namespace is written twice within a TTL window.
- Stores `{ flags, timeoutId }` as a unit in `subFlags`.
- On TTL expiry: deletes the entry and calls `notifySubFlagSubscribers(key)` — scoped notification, not a global broadcast.
- Sub-context data never reaches `cacheAdapter`. Sub-context lifetime is tied to the live component instance; it does not need to survive a page reload. A reload re-mounts Gate, which re-derives its override context from props and re-requests via `updateContext()`.
 
**`subscribe(callback, subContextKey?)`** — extended with optional second argument:
- No `subContextKey` → global subscriber path, unchanged.
- `subContextKey` provided → registers under `subFlagSubscribers.get(key)`. Immediate callback passes current sub-context flags if already resolved, or `{}` (pending state) if the context fetch hasn't completed yet. Unsubscribe cleans up the `Set` entry and removes the key from the Map entirely when the last subscriber for that key leaves.
 
**`getFlag(key, fallback, subContextKey?)`**:
- `subContextKey` provided and found → reads from `subFlags.get(key).flags`.
- `subContextKey` provided but not found (pending or expired) → returns `fallback`. Does **not** fall through to global `this.flags`. An override read that silently degrades to the global value is indistinguishable from a correctly resolved override at the call site.
- No `subContextKey` → unchanged.
 
**`getFlags()`** — return type corrected from `FeatureFlags<T> | Record<string, FeatureFlags<T>>` back to `FeatureFlags<T>`. Sub-context flags no longer pollute `this.flags`, so the union type is gone.
 
**`FlagUpdateCallback<T>`** — type corrected from `(flags: FeatureFlags<T> | Record<string, FeatureFlags<T>>)` to `(flags: FeatureFlags<T>)`. Both the global and sub-context notify paths now pass a flat `FeatureFlags<T>` bag.
 
**`destroy()`** — now drains all sub-context timers before clearing the Map:
```ts
this.subFlags.forEach(({ timeoutId }) => {
  if (timeoutId) clearTimeout(timeoutId);
});
this.subFlags.clear();
this.subFlagSubscribers.clear();
```
 
---
 
### `flagmint-vuejs-feature-flags` — `<FlagmintFeatureGate>`
 
**New prop: `contextNamespace`** (`String`, optional)
 
Scopes flag evaluation to an isolated namespace on the client. Ephemeral — not cached, not shared with other components, cleared on unmount. Has no effect on the global client context or any other Gate.
 
**`evaluate()`** — now passes `props.contextNamespace` to `getFlag()`:
```ts
const value = client.getFlag(key, false, props.contextNamespace);
```
 
**`onMounted` subscribe** — now passes `props.contextNamespace` to `subscribe()`:
```ts
unsubscribe = client.subscribe((flags) => {
  enabled.value = keys.every(key => flags[key] === true);
}, props.contextNamespace);
```
 
When `contextNamespace` is set, Gate only re-renders when its own sub-context updates or expires — not on global flag pushes or other Gates' sub-context changes.
 
---
 
### Not changed
 
- `plugin.ts` global reactivity trigger (`client.subscribe(() => { flagStateRef.value++ })`) remains on the global path. Sub-context updates do not increment `flagStateRef` — they notify only the specific Gate(s) registered under that namespace.
- `updateContext()` signature and behaviour unchanged. Gate calls `updateContext(props.context, { key: props.contextNamespace })` to trigger a sub-context fetch; the options threading through to `updateFlags()` was already in place.
- Long-polling and WebSocket transport `onFlagsUpdated` handlers call `updateFlags(updatedFlags)` with no options — global path only, unchanged.
 
---
 
## Usage
 
```vue
<template>
  <!-- Evaluated against global context — unchanged behaviour -->
  <FlagmintFeatureGate feature-keys="new-dashboard">
    <NewDashboard />
  </FlagmintFeatureGate>
 
  <!-- Evaluated in isolation against this user's context -->
  <!-- Does not affect the global client or any other Gate -->
  <FlagmintFeatureGate
    feature-keys="pro-export"
    context-namespace="user-pro-export-gate"
  >
    <ExportButton />
  </FlagmintFeatureGate>
</template>
 
<script setup>
import { onMounted } from 'vue';
import { useFlagClient } from 'flagmint-vuejs-feature-flags';
 
const client = useFlagClient();
 
onMounted(async () => {
  // Fetch flags scoped to this namespace — does not overwrite global context
  await client.value?.updateContext(
    { plan: 'pro', userId: 'user-123' },
    { key: 'user-pro-export-gate', subFlagTTL: 5 * 60 * 1000 }
  );
});
</script>
```
 
---
 
## Known limitations
 
- `contextNamespace` changing at runtime after mount does not re-register the subscription or re-trigger `evaluate()`. Treat it as a mount-time-stable prop. If dynamic namespace switching is needed, unmount and remount Gate.
- Gate currently only supports boolean flags. Non-boolean flag type support (`string`, `number`, `JSON`) is tracked separately and is not part of this PR.
 
---
 
## Testing
 
- [ ] Gate with no `contextNamespace` evaluates against global flags — no behaviour change.
- [ ] Gate with `contextNamespace` evaluates against sub-context flags only.
- [ ] Two Gates with different `contextNamespace` values do not trigger each other's subscribers on update or expiry.
- [ ] Sub-context write followed by a second write to the same key before TTL expiry — only one timer remains armed; the earlier one does not delete the later write's data.
- [ ] TTL expiry delivers `{}` to the Gate's subscriber, causing Gate to fall back to `fallback` values.
- [ ] `getFlag(key, fallback, expiredOrMissingKey)` returns `fallback`, not the global flag value.
- [ ] `destroy()` with active sub-context timers — no post-destroy callbacks fire.
- [ ] Page reload with `enableOfflineCache: true` — no sub-context data appears in the loaded cache; client boots with global flags only.
- [ ] `plugin.ts` global `flagStateRef` is not incremented by sub-context updates.